### PR TITLE
Add CodeDeploy configuration to the API project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
 - grunt dist
 - grunt codedeploy
 deploy:
-  matrix:
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,49 @@ language: node_js
 node_js:
   - "0.10"
 before_install: npm install -g grunt-cli
-install: npm install
+install:
+  - npm install
+  - grunt test
+  - grunt dist
+  - grunt codedeploy
+deploy:
+  - provider: s3
+    access_key_id: AKIAIMTOX4BXGVFOB56Q
+    secret_access_key:
+      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+    skip_cleanup: true
+    bucket: hmda-edit-check-api
+    local_dir: dist
+    upload-dir: develop
+    on:
+      all_branches: true
+  - provider: codedeploy
+    access_key_id: AKIAIMTOX4BXGVFOB56Q
+    secret_access_key:
+      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+    bucket: hmda-edit-check-api
+    key: develop/hmda-edit-check-api.zip
+    application: hmda-edit-check-api
+    deployment_group: hmda-pilot-dev
+    on:
+      all_branches: true
+  - provider: s3
+    access_key_id: AKIAIMTOX4BXGVFOB56Q
+    secret_access_key:
+      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+    skip_cleanup: true
+    bucket: hmda-edit-check-api
+    local_dir: dist
+    upload-dir: master
+    on:
+      branch: master
+  - provider: codedeploy
+    access_key_id: AKIAIMTOX4BXGVFOB56Q
+    secret_access_key:
+      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+    bucket: hmda-edit-check-api
+    key: master/hmda-edit-check-api-codedeploy.zip
+    application: hmda-edit-check-api
+    deployment_group: hmda-pilot-prod
+    on:
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
 - grunt dist
 - grunt codedeploy
 deploy:
-  matrix:
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
@@ -49,5 +48,3 @@ deploy:
     deployment_group: hmda-edit-check-api-dev
     on:
       branch: master
-  secret_access_key:
-    secure: Ptqremgo84uZl2BB4vkTf1t8tezdMeWUyUXrkliPQU2SWfubbBqyU99zxG2E4kEOmMMOnisj3Po9emEfOnx1U66kFaJ5SFTSvobY7tHLIKCaRnssZV9swzQNJJQFgPIU7bm+YGHbdNn0GpBnkqU09dC3SAgEpuycadqrhoEqkUw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,45 +8,47 @@ install:
 - grunt dist
 - grunt codedeploy
 deploy:
-  - provider: s3
-    access_key_id: AKIAIMTOX4BXGVFOB56Q
-    secret_access_key:
-      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
-    skip_cleanup: true
-    bucket: hmda-edit-check-api
-    local_dir: dist
-    upload-dir: develop
-    on:
-      all_branches: true
-  - provider: codedeploy
-    access_key_id: AKIAIMTOX4BXGVFOB56Q
-    secret_access_key:
-      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
-    bucket: hmda-edit-check-api
-    key: develop/hmda-edit-check-api-codedeploy.zip
-    application: hmda-edit-check-api
-    deployment_group: hmda-edit-check-api-dev
-    on:
-      all_branches: true
-  - provider: s3
-    access_key_id: AKIAIMTOX4BXGVFOB56Q
-    secret_access_key:
-      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
-    skip_cleanup: true
-    bucket: hmda-edit-check-api
-    local_dir: dist
-    upload-dir: master
-    on:
-      branch: master
-  - provider: codedeploy
-    access_key_id: AKIAIMTOX4BXGVFOB56Q
-    secret_access_key:
-      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
-    bucket: hmda-edit-check-api
-    key: master/hmda-edit-check-api-codedeploy.zip
-    application: hmda-edit-check-api
-    deployment_group: hmda-edit-check-api-dev
-    on:
-      branch: master
+- provider: s3
+  access_key_id: AKIAIMTOX4BXGVFOB56Q
+  secret_access_key:
+    secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
+  skip_cleanup: true
+  bucket: hmda-edit-check-api
+  local_dir: dist
+  upload-dir: develop
+  on:
+    all_branches: true
+- provider: codedeploy
+  access_key_id: AKIAIMTOX4BXGVFOB56Q
+  secret_access_key:
+    secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
+  bucket: hmda-edit-check-api
+  key: develop/hmda-edit-check-api-codedeploy.zip
+  application: hmda-edit-check-api
+  deployment_group: hmda-edit-check-api-dev
+  on:
+    all_branches: true
+- provider: s3
+  access_key_id: AKIAIMTOX4BXGVFOB56Q
+  secret_access_key:
+    secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
+  skip_cleanup: true
+  bucket: hmda-edit-check-api
+  local_dir: dist
+  upload-dir: master
+  on:
+    branch: master
+- provider: codedeploy
+  access_key_id: AKIAIMTOX4BXGVFOB56Q
+  secret_access_key:
+    secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
+  bucket: hmda-edit-check-api
+  key: master/hmda-edit-check-api-codedeploy.zip
+  application: hmda-edit-check-api
+  deployment_group: hmda-edit-check-api-dev
+  on:
+    branch: master
 notifications:
-  hipchat: 45e993644c60fb1addec6c943d38dd@871568
+  hipchat:
+    rooms:
+      secure: FkfhXmbIG/0ysT8l0mTh8IZ4hj/PmqR0dTba8u2U4stZLxPJn4Ac0yeTAB7XIll4o3TGNR6vYFfamYGX0ulOlv5RQps97JDETFztuy6r7nafcQftizSjipFqF4P5NZNObtSdlGCOw1slOEpuqigpowNA6KRbwpUlVSUK3J4MA5s=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
 - grunt dist
 - grunt codedeploy
 deploy:
+  matrix:
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
@@ -48,3 +49,5 @@ deploy:
     deployment_group: hmda-edit-check-api-dev
     on:
       branch: master
+  secret_access_key:
+    secure: Ptqremgo84uZl2BB4vkTf1t8tezdMeWUyUXrkliPQU2SWfubbBqyU99zxG2E4kEOmMMOnisj3Po9emEfOnx1U66kFaJ5SFTSvobY7tHLIKCaRnssZV9swzQNJJQFgPIU7bm+YGHbdNn0GpBnkqU09dC3SAgEpuycadqrhoEqkUw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,5 @@ deploy:
     deployment_group: hmda-edit-check-api-dev
     on:
       branch: master
+notifications:
+  hipchat: 45e993644c60fb1addec6c943d38dd@871568

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ deploy:
     secret_access_key:
       secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
     bucket: hmda-edit-check-api
-    key: develop/hmda-edit-check-api.zip
+    key: develop/hmda-edit-check-api-codedeploy.zip
     application: hmda-edit-check-api
     deployment_group: hmda-edit-check-api-dev
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ deploy:
     bucket: hmda-edit-check-api
     local_dir: dist
     upload-dir: develop
-    on:
-      branch: **
   - provider: codedeploy
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
@@ -26,8 +24,6 @@ deploy:
     key: develop/hmda-edit-check-api.zip
     application: hmda-edit-check-api
     deployment_group: hmda-pilot-dev
-    on:
-      branch: **
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ deploy:
     bucket: hmda-edit-check-api
     local_dir: dist
     upload-dir: develop
+    on:
+      branch: milestone3
   - provider: codedeploy
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
@@ -24,6 +26,8 @@ deploy:
     key: develop/hmda-edit-check-api.zip
     application: hmda-edit-check-api
     deployment_group: hmda-pilot-dev
+    on:
+      branch: milestone3
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: node_js
 node_js:
-  - "0.10"
+- '0.10'
 before_install: npm install -g grunt-cli
 install:
-  - npm install
-  - grunt test
-  - grunt dist
-  - grunt codedeploy
+- npm install
+- grunt test
+- grunt dist
+- grunt codedeploy
 deploy:
+  matrix:
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
-      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
     skip_cleanup: true
     bucket: hmda-edit-check-api
     local_dir: dist
@@ -21,7 +22,7 @@ deploy:
   - provider: codedeploy
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
-      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
     bucket: hmda-edit-check-api
     key: develop/hmda-edit-check-api.zip
     application: hmda-edit-check-api
@@ -31,7 +32,7 @@ deploy:
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
-      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
     skip_cleanup: true
     bucket: hmda-edit-check-api
     local_dir: dist
@@ -41,7 +42,7 @@ deploy:
   - provider: codedeploy
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
-      secure: LZToB5h0IoW4K21i2gYT4cdiWjzlb8rnz7pL8gL/y/gRX9UjWr2xHDtNgBbAi8nQcle0/z4NgwG2UzfaP4EmKN09P9WFyUtmIOtwO8cPMqg0L/W8pP6gWe/Ebfd42AILJ/niuklP79Hb9m71pNJfm+XhFbWXCEDAo3DYFa1uYEE=
+      secure: NxMG05K8yLXd8XH4U+u2B5kF4Tr0HoIox3qUKWi4BqLK5Ze2dMaCHQZCBz2hCrdPY+Jj5AiktyTF9PeRn2gz/jOsT5XVh/I1XG7xk7s6w6ml13vdwNbp2ZVo0ENXjmQ1OT44a8QebhbqJwjiaQ2sERGNRM6nqbKpwOFdbL50VoQ=
     bucket: hmda-edit-check-api
     key: master/hmda-edit-check-api-codedeploy.zip
     application: hmda-edit-check-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     local_dir: dist
     upload-dir: develop
     on:
-      all_branches: true
+      branch: **
   - provider: codedeploy
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
@@ -27,7 +27,7 @@ deploy:
     application: hmda-edit-check-api
     deployment_group: hmda-pilot-dev
     on:
-      all_branches: true
+      branch: **
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
     local_dir: dist
     upload-dir: develop
     on:
-      branch: milestone3
+      all_branches: true
   - provider: codedeploy
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
@@ -25,9 +25,9 @@ deploy:
     bucket: hmda-edit-check-api
     key: develop/hmda-edit-check-api.zip
     application: hmda-edit-check-api
-    deployment_group: hmda-pilot-dev
+    deployment_group: hmda-edit-check-api-dev
     on:
-      branch: milestone3
+      all_branches: true
   - provider: s3
     access_key_id: AKIAIMTOX4BXGVFOB56Q
     secret_access_key:
@@ -45,6 +45,6 @@ deploy:
     bucket: hmda-edit-check-api
     key: master/hmda-edit-check-api-codedeploy.zip
     application: hmda-edit-check-api
-    deployment_group: hmda-pilot-prod
+    deployment_group: hmda-edit-check-api-dev
     on:
       branch: master

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,4 +36,5 @@ module.exports = function (grunt) {
     grunt.registerTask('coverage', ['test', 'open_coverage']);
     grunt.registerTask('dist', ['compress:hmda-edit-check-api']);
     grunt.registerTask('serve', ['env:sandbox', 'jshint','develop','watch']);
+    grunt.registerTask('codedeploy', ['compress:codedeploy']);
 };

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,8 @@
+version: 0.0
+os: linux
+files:
+  - source: dist/hmda-edit-check-api.zip
+    destination: /usr/local/nodefiles
+hooks:
+  AfterInstall:
+    - location: scripts/nodedeploy.bash

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -26,6 +26,19 @@ fi
 
 BASEDIR=/usr/local/APPS/node/${BASENAME}
 INITSCRIPT=/etc/init.d/${BASENAME}
+TMPDIRNAME=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+TMPDIR="/tmp/${TMPDIRNAME}"
+
+echo "Extacting new application to ${TMPDIR}"
+su - node -c "/usr/bin/unzip -q ${ZIPFILEPATH} -d ${TMPDIR}"
+
+echo "Running 'npm install'"
+su - node -c "cd $TMPDIR && npm install"
+
+echo "Running 'grunt dist'"
+su - node -c "cd $TMPDIR && grunt dist"
+
+ZIPFILEPATH="${TMPDIR}/dist/${ZIPFILE}"
 
 if [ -d "${BASEDIR}" ]; then
     echo "Removing old application at ${BASEDIR}"

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -42,24 +42,17 @@ su - node -c "/usr/bin/unzip -q ${ZIPFILEPATH} -d ${TMPDIR}"
 echo "Running 'npm install'"
 su - node -c "cd $TMPDIR && npm install"
 
-echo "Running 'grunt dist'"
-su - node -c "cd $TMPDIR && grunt dist"
-
-ZIPFILEPATH="${TMPDIR}/dist/${ZIPFILE}"
-
 if [ -d "${BASEDIR}" ]; then
     echo "Removing old application at ${BASEDIR}"
     /bin/rm -rf ${BASEDIR}
 fi
 
-echo "Extracting new application to ${BASEDIR}"
-/usr/bin/unzip -q ${ZIPFILEPATH} -d ${BASEDIR}
+echo "Moving new application to ${BASEDIR}"
+/bin/cp -r ${TMPDIR} ${BASEDIR}
 
 /bin/mkdir ${BASEDIR}/logs
-/bin/chown node:node ${BASEDIR}/logs
 
-echo "Removing zipfiles"
-/bin/rm "${ZIPFILEPATH}"
+echo "Removing zipfile"
 /bin/rm "${NODEDIR}/${ZIPFILE}"
 
 echo "Fix permissions"

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Name: nodedeploy.bash
+# Author: Michael Marod
+# Purpose: To automatically deploy node apps
+# Requires: zip file be located in /usr/local/nodefiles, this
+#       directory will be cleaned at the end of the script.
+#
+
+ZIPFILE=hmda-edit-check-api.zip
+
+if ! [[ $ZIPFILE =~ \.zip$ ]]; then
+   echo "$0 [zipfile]"
+   exit 1
+fi
+
+BASENAME=$(basename $ZIPFILE .zip)
+NODEDIR=/usr/local/nodefiles
+ZIPFILEPATH="${NODEDIR}/${ZIPFILE}"
+
+if [ ! -f $ZIPFILEPATH ]; then
+   echo "${ZIPFILEPATH} does not exist!"
+   echo "$0 [zipfile]"
+   exit 1
+fi
+
+BASEDIR=/usr/local/APPS/node/${BASENAME}
+INITSCRIPT=/etc/init.d/${BASENAME}
+
+if [ -d "${BASEDIR}" ]; then
+    echo "Removing old application at ${BASEDIR}"
+    /bin/rm -rf ${BASEDIR}
+fi
+
+echo "Extracting new application to ${BASEDIR}"
+/usr/bin/unzip -q ${ZIPFILEPATH} -d ${BASEDIR}
+
+/bin/mkdir ${BASEDIR}/logs
+/bin/chown node:node ${BASEDIR}/logs
+
+echo "Removing zipfile"
+/bin/rm ${ZIPFILEPATH}
+
+echo "Fix permissions"
+/bin/chown -R node:node ${BASEDIR}
+
+echo "Restarting Node"
+${INITSCRIPT} restart
+
+echo "Done!"

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -7,6 +7,13 @@
 #       directory will be cleaned at the end of the script.
 #
 
+TMPNAME=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+LOG="/tmp/${TMPNAME}.log"
+
+exec > >(tee $LOG)
+exec 2>&1
+
+TMPDIR="/tmp/${TMPNAME}"
 ZIPFILE=hmda-edit-check-api.zip
 
 if ! [[ $ZIPFILE =~ \.zip$ ]]; then
@@ -26,8 +33,6 @@ fi
 
 BASEDIR=/usr/local/APPS/node/${BASENAME}
 INITSCRIPT=/etc/init.d/${BASENAME}
-TMPDIRNAME=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-TMPDIR="/tmp/${TMPDIRNAME}"
 
 echo "Extacting new application to ${TMPDIR}"
 su - node -c "/usr/bin/unzip -q ${ZIPFILEPATH} -d ${TMPDIR}"

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -51,8 +51,9 @@ echo "Extracting new application to ${BASEDIR}"
 /bin/mkdir ${BASEDIR}/logs
 /bin/chown node:node ${BASEDIR}/logs
 
-echo "Removing zipfile"
-/bin/rm ${ZIPFILEPATH}
+echo "Removing zipfiles"
+/bin/rm "${ZIPFILEPATH}"
+/bin/rm "${NODEDIR}/${ZIPFILE}"
 
 echo "Fix permissions"
 /bin/chown -R node:node ${BASEDIR}

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -13,6 +13,8 @@ LOG="/tmp/${TMPNAME}.log"
 exec > >(tee $LOG)
 exec 2>&1
 
+npm install -g npm@next
+npm install -g grunt-cli
 TMPDIR="/tmp/${TMPNAME}"
 ZIPFILE=hmda-edit-check-api.zip
 

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -21,10 +21,7 @@ module.exports = function compress(grunt) {
                     src: [ '**',
                         '!coverage/**',
                         '!test/**',
-                        '!node_modules/grunt*/**',
-                        '!node_modules/istanbul/**',
-                        '!node_modules/mocha/**',
-                        '!node_modules/supertest/**'
+                        '!node_modules/**'
                     ]
                 }
             ]

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -28,6 +28,23 @@ module.exports = function compress(grunt) {
                     ]
                 }
             ]
+        },
+        'codedeploy': {
+          options: {
+            archive: './dist/hmda-edit-check-api-codedeploy.zip',
+            mode: 'zip',  //zip | gzip | deflate | tgz
+            pretty: true
+          },
+          files: [
+            {
+              expand: true,
+              dot: true,
+              cwd: './',
+
+              //zip dist directory
+              src: ['dist/hmda-edit-check-api.zip', 'scripts/*', 'appspec.yml']
+            }
+          ]
         }
     };
 

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -47,5 +47,4 @@ module.exports = function compress(grunt) {
           ]
         }
     };
-
 };


### PR DESCRIPTION
Sets up .travis.yml and appspec.yml to leverage AWS CodeDeploy to perform code deployments. I updated the compress task for this project and removed node_modules entirely from the zip archive. This is because the npm install command should be run on the app server and not on TravisCI and archived... I ran into an issue with glibc6 version mismatches if this is not done.

Once this is merged in, we will need to directly update the AWS secret key in the milestone3 branch in the CFPB repository. Travis does not let you merge forked secret keys back into the main repo for security. http://docs.travis-ci.com/user/environment-variables/#Secure-Variables

I didn't see an issue to mention for this so I didn't mention one ;)