### PR TITLE
Fix deploy tasks 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js:
 - '0.10'
 before_install: npm install -g grunt-cli
 install: npm install
-after_script:
+script:
+- npm test
 - grunt dist
 - grunt codedeploy
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - '0.10'
 before_install: npm install -g grunt-cli
 install: npm install
-before_deploy:
+after_script:
 - grunt dist
 - grunt codedeploy
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
 before_install: npm install -g grunt-cli
 install: npm install
 after_script:
-- "grunt dist"
-- "grunt codedeploy"
+- grunt dist
+- grunt codedeploy
 deploy:
 - provider: s3
   access_key_id: AKIAIMTOX4BXGVFOB56Q

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
 before_install: npm install -g grunt-cli
 install: npm install
 after_script:
-- grunt dist
-- grunt codedeploy
+- "grunt dist"
+- "grunt codedeploy"
 deploy:
 - provider: s3
   access_key_id: AKIAIMTOX4BXGVFOB56Q

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   "homepage": "https://github.com/cfpb/hmda-edit-check-api",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test",
-    "dist": "grunt dist",
-    "codedeploy": "grunt codedeploy"
+    "test": "grunt test"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "main": "index.js",
   "scripts": {
     "test": "grunt test"
+    "dist": "grunt dist"
+    "codedeploy": "grunt codedeploy"
   },
   "dependencies": {
     "async": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "homepage": "https://github.com/cfpb/hmda-edit-check-api",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test"
-    "dist": "grunt dist"
+    "test": "grunt test",
+    "dist": "grunt dist",
     "codedeploy": "grunt codedeploy"
   },
   "dependencies": {

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -19,7 +19,6 @@ module.exports = function compress(grunt) {
 
                     //zip all files except coverage, test dirs and the grunt/test modules
                     src: [ '**',
-//                        '!data/**',
                         '!coverage/**',
                         '!test/**',
                         '!node_modules/**'

--- a/tasks/compress.js
+++ b/tasks/compress.js
@@ -19,7 +19,7 @@ module.exports = function compress(grunt) {
 
                     //zip all files except coverage, test dirs and the grunt/test modules
                     src: [ '**',
-                        '!data/**',
+//                        '!data/**',
                         '!coverage/**',
                         '!test/**',
                         '!node_modules/**'


### PR DESCRIPTION
For #17, the 'grunt dist' command was running multiple times preventing it from deploying properly. This was fixed by moving the commands from 'before_deploy' to 'script' and manually specifying 'npm test'.