### PR TITLE
Update Node deploy script to reload the database

### DIFF
--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -9,7 +9,6 @@
 
 TMPNAME=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
 LOG="/tmp/${TMPNAME}.log"
-MONGODB_NAME=hmda
 
 exec > >(tee $LOG)
 exec 2>&1

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -73,6 +73,6 @@ echo "Fix permissions"
 /bin/chown -R node:node ${BASEDIR}
 
 echo "Restarting Node"
-${INITSCRIPT} restart
+${INITSCRIPT} start
 
 echo "Done!"

--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -47,7 +47,7 @@ diff -q ${BASEDIR}/data ${TMPDIR}/data
 
 if [ "$?" -ne "0" ]; then
     echo "${BASEDIR}/data ${TMPDIR}/data and differ... Re-populating the ${NODE_ENV} database."
-    su - node -c "cd ${TMPDIR}/data && node reload_mongo.js"
+    su - node -c "cd ${TMPDIR} && node data/reload_mongo.js"
 else
     echo "No database updates."
 fi


### PR DESCRIPTION
For #17, this will run a Node script that will repopulate the database if there is a diff between the new data model and the existing one on the server.

It relies on reload_mongo.js existing so it won't work until that script is there. Adam is working on that script currently. You can merge this in and nothing will break unless the data model changes between the time this is merged in and the time adam merges in his reload_mongo.js script.