### PR TITLE
remove codedeploy tmp dir to save disk space

### DIFF
--- a/scripts/nodedeploy.bash
+++ b/scripts/nodedeploy.bash
@@ -68,6 +68,9 @@ echo "Moving new application to ${BASEDIR}"
 echo "Removing zipfile"
 /bin/rm "${NODEDIR}/${ZIPFILE}"
 
+echo "Removing codedeploy temp directory"
+/bin/rm -rf "${TMPDIR}"
+
 echo "Fix permissions"
 /bin/chown -R node:node ${BASEDIR}
 


### PR DESCRIPTION
Remove the temp dir on deploy to save disk space.