### PR TITLE
fixes to Q033, Q075, Q076 based off requirements clarifications

### DIFF
--- a/controllers/isValidNumLoans/homePurchase.js
+++ b/controllers/isValidNumLoans/homePurchase.js
@@ -8,8 +8,8 @@ module.exports = function(router) {
      * @param {String} activityYear, {String} agencyCode, {String} respondentID, {String} numLoans
      * @return {json}
      */
-    router.get('/:activityYear/:agencyCode/:respondentID/:numLoans/', function(req, res) {
-        LARService.isValidNumHomePurchaseLoans(req.params.activityYear, req.params.agencyCode, req.params.respondentID, req.params.numLoans, function(err, result) {
+    router.get('/:activityYear/:agencyCode/:respondentID/:numLoans/:numSoldLoans', function(req, res) {
+        LARService.isValidNumHomePurchaseLoans(req.params.activityYear, req.params.agencyCode, req.params.respondentID, req.params.numLoans, req.params.numSoldLoans, function(err, result) {
             if (err) {
                 res.status(500).json(err);
             } else {

--- a/controllers/isValidNumLoans/refinance.js
+++ b/controllers/isValidNumLoans/refinance.js
@@ -8,8 +8,8 @@ module.exports = function(router) {
      * @param {String} activityYear, {String} agencyCode, {String} respondentID, {String} numLoans
      * @return {json}
      */
-    router.get('/:activityYear/:agencyCode/:respondentID/:numLoans/', function(req, res) {
-        LARService.isValidNumRefinanceLoans(req.params.activityYear, req.params.agencyCode, req.params.respondentID, req.params.numLoans, function(err, result) {
+    router.get('/:activityYear/:agencyCode/:respondentID/:numLoans/:numSoldLoans', function(req, res) {
+        LARService.isValidNumRefinanceLoans(req.params.activityYear, req.params.agencyCode, req.params.respondentID, req.params.numLoans, req.params.numSoldLoans, function(err, result) {
             if (err) {
                 res.status(500).json(err);
             } else {

--- a/services/LARService.js
+++ b/services/LARService.js
@@ -18,8 +18,17 @@ var compareYearTotals = function(newLoans, oldLoans, percentage) {
     return result;
 };
 
-var comparePercentages = function (newPercentage, oldPercentage, threshold) {
-    var diff = newPercentage - oldPercentage;
+var checkMaximumPercentageChange = function (newPercentage, oldPercentage, threshold) {
+    var diff = Math.abs((newPercentage - oldPercentage).toFixed(2));
+    if (diff < threshold) {
+        return true;
+    }
+    return false;
+};
+
+var comparePercentages = function (newPercentage, oldPercentage, threshold, range) {
+    var diff = (newPercentage - oldPercentage).toFixed(2);
+
     if (diff < threshold) {
         return false;
     }
@@ -60,10 +69,14 @@ var calculateYearOnYearLoans = function (currentLoans, currentSoldLoans,
 
         // diff year to year can't be more than threshold, if over largeNum,
         // then currentPercentage should be greater than minPercent
-        if (comparePercentages(currentPercent, previousYearPercent, loanParameters.diffPercent) &&
-            ((currentLoans>=loanParameters.threshold && currentPercent> loanParameters.minPercent) || currentLoans<loanParameters.threshold)) {
+        if (loanParameters.threshold=== undefined && 
+                checkMaximumPercentageChange(currentPercent, previousYearPercent, loanParameters.diffPercent)) {
             result.result = true;
+        } else if (comparePercentages(currentPercent, previousYearPercent, loanParameters.diffPercent) &&
+            ((currentLoans>=loanParameters.threshold && currentPercent> loanParameters.minPercent) || currentLoans<loanParameters.threshold)) {
+            result.result = true; 
         }
+
         return callback(null, result);
 
     })
@@ -73,25 +86,25 @@ var calculateYearOnYearLoans = function (currentLoans, currentSoldLoans,
 };
 
 module.exports = {
-    isValidNumHomePurchaseLoans: function(activityYear, agencyCode, respondentID, newLoans, callback) {
+    isValidNumHomePurchaseLoans: function(activityYear, agencyCode, respondentID, currentLoans, currentSoldLoans, callback) {
         activityYear -= 1;
-        var query = {
+        var totalQuery = {
             'activity_year': activityYear,
             'respondent_id': respondentID,
             'agency_code': agencyCode,
             'loan_purpose': '1',
             'action_type': {$in: ['1', '6']},
             'property_type': {$in: ['1', '2']},
-            'purchaser_type': {$ne: '0'}
+        };
+        var soldQuery = _.clone(totalQuery);
+        soldQuery.purchaser_type = {$ne: '0'};
+
+        var loanParameters = {
+            diffPercent: 0.2
         };
 
-        LAR.count(query, function(err, oldLoans) {
-            if (err) {
-                return callback(err, null);
-            }
-            var result = compareYearTotals(newLoans, oldLoans, 0.2);
-            return callback(null, result);
-        });
+        return calculateYearOnYearLoans (currentLoans, currentSoldLoans,
+            totalQuery, soldQuery, loanParameters, callback);
     },
     isValidNumLoans: function(activityYear, agencyCode, respondentID, newLoans, callback) {
         activityYear -= 1;
@@ -100,6 +113,7 @@ module.exports = {
             'respondent_id': respondentID,
             'agency_code': agencyCode
         };
+
 
         LAR.count(query, function(err, oldLoans) {
             if (err) {
@@ -114,26 +128,25 @@ module.exports = {
             return callback(null, result);
         });
     },
-    isValidNumRefinanceLoans: function(activityYear, agencyCode, respondentID, newLoans, callback) {
+    isValidNumRefinanceLoans: function(activityYear, agencyCode, respondentID, currentLoans, currentSoldLoans, callback) {
         activityYear -= 1;
-        var query = {
+        var totalQuery = {
             'activity_year': activityYear,
             'respondent_id': respondentID,
             'agency_code': agencyCode,
             'loan_purpose': '3',
             'action_type': {$in: ['1', '6']},
-            'property_type': {$in: ['1', '2']},
-            'purchaser_type': {$ne: '0'}
+            'property_type': {$in: ['1', '2']}
+        };
+        var soldQuery = _.clone(totalQuery);
+        soldQuery.purchaser_type = {$ne: '0'};
+
+        var loanParameters = {
+            diffPercent: 0.2
         };
 
-        LAR.count(query, function(err, oldLoans) {
-            if (err) {
-                return callback(err, null);
-            }
-
-            var result = compareYearTotals(newLoans, oldLoans, 0.2);
-            return callback(null, result);
-        });
+        return calculateYearOnYearLoans (currentLoans, currentSoldLoans,
+            totalQuery, soldQuery, loanParameters, callback);
     },
     isValidNumFannieLoans: function(activityYear, agencyCode, respondentID, currentLoans, currentFannieLoans, callback) {
         activityYear -= 1;

--- a/services/PanelService.js
+++ b/services/PanelService.js
@@ -6,7 +6,7 @@ var exists = require('../lib/queryUtil').exists;
 
 module.exports = {
     isChildFI: function(activityYear, agencyCode, respondentId, callback) {
-        var query = {'activity_year': activityYear, 'respondent_id': respondentId, 'agency_code': agencyCode, 'parent_name': {'$ne': ''}, 'other_lender_code': '0'};
+        var query = {'activity_year': activityYear, 'respondent_id': respondentId, 'agency_code': agencyCode, 'parent_name': {'$ne': ''}, 'other_lender_code': {'$ne': '5'}};
         exists('Panel', query, callback);
     },
 

--- a/test/controllers/homePurchaseSpec.js
+++ b/test/controllers/homePurchaseSpec.js
@@ -9,7 +9,7 @@ describe('/isValidNumLoans/homePurchase', function() {
         async.series([
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/9')
+                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/10/5')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":true/)
@@ -20,7 +20,7 @@ describe('/isValidNumLoans/homePurchase', function() {
             },
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/11')
+                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/10/7')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":true/)
@@ -38,7 +38,7 @@ describe('/isValidNumLoans/homePurchase', function() {
         async.series([
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/3')
+                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/10/10')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -49,7 +49,7 @@ describe('/isValidNumLoans/homePurchase', function() {
             },
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/17')
+                    .get('/isValidNumLoans/homePurchase/2013/9/0002590037/10/3')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -65,7 +65,7 @@ describe('/isValidNumLoans/homePurchase', function() {
 
     it('should return true when there are no home purchase loans for either year', function(done) {
         request(mock)
-            .get('/isValidNumLoans/homePurchase/2013/9/0002590058/0')
+            .get('/isValidNumLoans/homePurchase/2013/9/0002590058/0/0')
             .expect(200)
             .expect('Content-Type', /json/)
             .expect(/"result":true/)
@@ -79,7 +79,7 @@ describe('/isValidNumLoans/homePurchase', function() {
         async.series([
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/homePurchase/2013/9/0002590058/8')
+                    .get('/isValidNumLoans/homePurchase/2013/9/0002590058/10/4')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -90,7 +90,7 @@ describe('/isValidNumLoans/homePurchase', function() {
             },
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/homePurchase/2013/9/0002590058/12')
+                    .get('/isValidNumLoans/homePurchase/2013/9/0002590058/10/8')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -103,24 +103,13 @@ describe('/isValidNumLoans/homePurchase', function() {
             done();
         });
     });
-
-    it('should return false when the percentage increase is infinite (n / 0)', function(done) {
-        request(mock)
-            .get('/isValidNumLoans/homePurchase/2013/9/0002590058/7')
-            .expect(200)
-            .expect('Content-Type', /json/)
-            .expect(/"result":false/)
-
-            .end(function (err, res) {
-                done(err);
-            });
-    });
+    
 
     it('should return a 500 if there is a problem', function(done) {
         mockgoose.setMockReadyState(mongoose.connection, 0);
 
         request(mock)
-            .get('/isValidNumLoans/homePurchase/2013/9/0002590037/5')
+            .get('/isValidNumLoans/homePurchase/2013/9/0002590037/10/5')
             .expect(500)
             .expect('Content-Type', /json/)
             .expect(/"code":/)

--- a/test/controllers/refinanceSpec.js
+++ b/test/controllers/refinanceSpec.js
@@ -9,7 +9,7 @@ describe('/isValidNumLoans/refinance', function() {
         async.series([
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/refinance/2013/9/1035818356/9')
+                    .get('/isValidNumLoans/refinance/2013/9/1035818356/10/5')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":true/)
@@ -20,7 +20,7 @@ describe('/isValidNumLoans/refinance', function() {
             },
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/refinance/2013/9/1035818356/11')
+                    .get('/isValidNumLoans/refinance/2013/9/1035818356/10/6')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":true/)
@@ -38,7 +38,7 @@ describe('/isValidNumLoans/refinance', function() {
         async.series([
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/refinance/2013/9/1035818356/3')
+                    .get('/isValidNumLoans/refinance/2013/9/1035818356/10/8')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -49,7 +49,7 @@ describe('/isValidNumLoans/refinance', function() {
             },
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/refinance/2013/9/1035818356/17')
+                    .get('/isValidNumLoans/refinance/2013/9/1035818356/10/2')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -65,7 +65,7 @@ describe('/isValidNumLoans/refinance', function() {
 
     it('should return true when there are no refinance loans for either year', function(done) {
         request(mock)
-            .get('/isValidNumLoans/refinance/2013/9/000000000005/0')
+            .get('/isValidNumLoans/refinance/2013/9/000000000005/0/0')
             .expect(200)
             .expect('Content-Type', /json/)
             .expect(/"result":true/)
@@ -79,7 +79,7 @@ describe('/isValidNumLoans/refinance', function() {
         async.series([
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/refinance/2013/9/1035818356/8')
+                    .get('/isValidNumLoans/refinance/2013/9/1035818356/10/7')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -90,7 +90,7 @@ describe('/isValidNumLoans/refinance', function() {
             },
             function(cb) {
                 request(mock)
-                    .get('/isValidNumLoans/refinance/2013/9/1035818356/12')
+                    .get('/isValidNumLoans/refinance/2013/9/1035818356/10/3')
                     .expect(200)
                     .expect('Content-Type', /json/)
                     .expect(/"result":false/)
@@ -104,23 +104,11 @@ describe('/isValidNumLoans/refinance', function() {
         });
     });
 
-    it('should return false when the percentage increase is infinite (n / 0)', function(done) {
-        request(mock)
-            .get('/isValidNumLoans/refinance/2013/9/000000000005/7')
-            .expect(200)
-            .expect('Content-Type', /json/)
-            .expect(/"result":false/)
-
-            .end(function (err, res) {
-                done(err);
-            });
-    });
-
     it('should return a 500 if there is a problem', function(done) {
         mockgoose.setMockReadyState(mongoose.connection, 0);
 
         request(mock)
-            .get('/isValidNumLoans/refinance/2013/9/0002590037/5')
+            .get('/isValidNumLoans/refinance/2013/9/0002590037/10/5')
             .expect(500)
             .expect('Content-Type', /json/)
             .expect(/"code":/)

--- a/test/services/LARServiceSpec.js
+++ b/test/services/LARServiceSpec.js
@@ -8,13 +8,13 @@ describe('LARService', function() {
         it('should return true for a valid number of home purchase loans', function(done) {
             async.series([
                 function(cb) {
-                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 9, function(err, result) {
+                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 10, 7,function(err, result) {
                         expect(result.result).to.be.true();
                         cb();
                     });        
                 },
                 function(cb) {
-                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 11, function(err, result) {
+                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 11, 8,function(err, result) {
                         expect(result.result).to.be.true();
                         cb();
                     });        
@@ -27,13 +27,13 @@ describe('LARService', function() {
         it('should return false an invalid number of home purchase loans', function(done) {
             async.series([
                 function(cb) {
-                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 3, function(err, result) {
+                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 10, 3,function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
                 },
                 function(cb) {
-                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 17, function(err, result) {
+                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 10, 9,function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
@@ -46,13 +46,13 @@ describe('LARService', function() {
         it('should return false when the percentage is exactly +/- 20%', function(done) {
             async.series([
                 function(cb) {
-                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 8, function(err, result) {
+                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 10, 8,function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
                 },
                 function(cb) {
-                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 12, function(err, result) {
+                    LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590037', 10, 4,function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
@@ -63,14 +63,14 @@ describe('LARService', function() {
         });
 
         it('should return true when there are no home purchase loans for either year', function(done) {
-            LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590058', 0, function(err, result) {
+            LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590058', 0, 0, function(err, result) {
                 expect(result.result).to.be.true();
                 done();
             });
         });
 
         it('should return false when the percentage increase is infinite (n / 0)', function(done) {
-            LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590058', 5, function(err, result) {
+            LARService.isValidNumHomePurchaseLoans('2013', '9', '0002590058', 5, 4, function(err, result) {
                 expect(result.result).to.be.false();
                 done();
             });
@@ -154,13 +154,13 @@ describe('LARService', function() {
         it('should return true when there are a valid number of refinance loans', function(done) {
             async.series([
                 function(cb) {
-                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 9, function(err, result) {
+                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 10, 5, function(err, result) {
                         expect(result.result).to.be.true();
                         cb();
                     });
                 },
                 function(cb) {
-                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 11, function(err, result) {
+                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 10, 6, function(err, result) {
                         expect(result.result).to.be.true();
                         cb();
                     });
@@ -173,13 +173,13 @@ describe('LARService', function() {
         it('should return false when there are an invalid number of refinance loans', function(done) {
             async.series([
                 function(cb) {
-                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 7, function(err, result) {
+                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 10, 8, function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
                 },
                 function(cb) {
-                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 13, function(err, result) {
+                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 10, 2, function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
@@ -192,13 +192,13 @@ describe('LARService', function() {
         it('should return false when the percentage is exactly +/- 20%', function(done) {
             async.series([
                 function(cb) {
-                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 8, function(err, result) {
+                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 10, 7, function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
                 },
                 function(cb) {
-                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 12, function(err, result) {
+                    LARService.isValidNumRefinanceLoans('2013', '9', '1035818356', 10, 3, function(err, result) {
                         expect(result.result).to.be.false();
                         cb();
                     });
@@ -209,15 +209,8 @@ describe('LARService', function() {
         });
 
         it('should return true when there are no home purchase loans for either year', function(done) {
-            LARService.isValidNumRefinanceLoans('2013', '9', '000000000005', 0, function(err, result) {
+            LARService.isValidNumRefinanceLoans('2013', '9', '000000000005', 0, 0, function(err, result) {
                 expect(result.result).to.be.true();
-                done();
-            });
-        });
-
-        it('should return false when the percentage increase is infinite (n / 0)', function(done) {
-            LARService.isValidNumRefinanceLoans('2013', '9', '000000000005', 8, function(err, result) {
-                expect(result.result).to.be.false();
                 done();
             });
         });

--- a/test/services/PanelServiceSpec.js
+++ b/test/services/PanelServiceSpec.js
@@ -19,15 +19,15 @@ describe('PanelService', function() {
             });
         });
 
-        it('should return a result of false if the respondent has an other lender code of 1 and a non-blank parent name', function(done) {
-            PanelService.isChildFI('2013', '2', '0000000003', function(err, result) {
+        it('should return a result of false if the respondent has an other lender code of 5 and a non-blank parent name', function(done) {
+            PanelService.isChildFI('2013', '2', '0000000005', function(err, result) {
                 expect(result.result).to.be.false();
                 done();
             });
         });
 
-        it('should return a result of false if the respondent has an other lender code of 1 and a blank parent name', function(done) {
-            PanelService.isChildFI('2013', '2', '0000000004', function(err, result) {
+        it('should return a result of false if the respondent has an other lender code of 5 and a blank parent name', function(done) {
+            PanelService.isChildFI('2013', '2', '0000000006', function(err, result) {
                 expect(result.result).to.be.false();
                 done();
             });

--- a/test/testdata.js
+++ b/test/testdata.js
@@ -33,7 +33,9 @@ var TestData = {
                     { 'activity_year': '2013', 'respondent_id': '0000000001', 'other_lender_code': '0', 'parent_name': 'foo', 'agency_code': '1' },
                     { 'activity_year': '2013', 'respondent_id': '0000000002', 'other_lender_code': '0', 'parent_name': '', 'agency_code': '1' },
                     { 'activity_year': '2013', 'respondent_id': '0000000003', 'other_lender_code': '1', 'parent_name': 'foo', 'agency_code': '2' },
-                    { 'activity_year': '2013', 'respondent_id': '0000000004', 'other_lender_code': '1', 'parent_name': '', 'agency_code': '2' }
+                    { 'activity_year': '2013', 'respondent_id': '0000000004', 'other_lender_code': '1', 'parent_name': '', 'agency_code': '2' },
+                    { 'activity_year': '2013', 'respondent_id': '0000000005', 'other_lender_code': '5', 'parent_name': 'foo', 'agency_code': '2' },
+                    { 'activity_year': '2013', 'respondent_id': '0000000006', 'other_lender_code': '5', 'parent_name': '', 'agency_code': '2'}
                 ],
                 function(err, item) {
                     cb();
@@ -67,7 +69,7 @@ var TestData = {
                   'loan_purpose': '1',
                   'loan_amount': '00110',
                   'action_type': '1',
-                  'purchaser_type': '5',
+                  'purchaser_type': '0',
                   'property_type': '1'
                 },
                 {
@@ -78,7 +80,7 @@ var TestData = {
                   'loan_purpose': '1',
                   'loan_amount': '00110',
                   'action_type': '6',
-                  'purchaser_type': '4',
+                  'purchaser_type': '0',
                   'property_type': '1'
                 },
                 {
@@ -89,7 +91,7 @@ var TestData = {
                   'loan_purpose': '1',
                   'loan_amount': '00110',
                   'action_type': '6',
-                  'purchaser_type': '7',
+                  'purchaser_type': '0',
                   'property_type': '1'
                 },
                 {
@@ -168,17 +170,6 @@ var TestData = {
                   'action_type': '1',
                   'purchaser_type': '2',
                   'property_type': '2'
-                },
-                {
-                  'activity_year': '2012',
-                  'respondent_id': '0002590037',
-                  'agency_code': '9',
-                  'loan_type': '1',
-                  'loan_purpose': '1',
-                  'loan_amount': '00110',
-                  'action_type': '1',
-                  'purchaser_type': '2',
-                  'property_type': '2'
                 }
               ],
               function(err, item) {
@@ -196,6 +187,17 @@ var TestData = {
                     'loan_amount': '00110',
                     'action_type': '1',
                     'purchaser_type': '2',
+                    'property_type': '2'
+                  },
+                  sampleLar2 = {
+                    'activity_year': '2012',
+                    'respondent_id': '0201590731',
+                    'agency_code': '9',
+                    'loan_type': '1',
+                    'loan_purpose': '1',
+                    'loan_amount': '00110',
+                    'action_type': '1',
+                    'purchaser_type': '0',
                     'property_type': '2'
                   };
 
@@ -215,10 +217,13 @@ var TestData = {
 
               sampleLar.respondent_id = '1035818356';
               sampleLar.loan_purpose = '3';
+              sampleLar2.respondent_id = '1035818356';
+              sampleLar2.loan_purpose = '3';
               lars = [];
 
-              for (var k = 0; k < 10; k++) {
+              for (var k = 0; k < 5; k++) {
                 lars.push(sampleLar);
+                 lars.push(sampleLar2);
               }
 
               mongoose.model('Lar').create(lars, function(err, item) {


### PR DESCRIPTION
Q033 now has other lender code not equaling 5,
Q075 and Q076 need a number of sold loans, since the requirement is to actually compare the percentages of sold loans year on year instead of comparing the number of loans year on year.