### PR TITLE
Make sure we only include keyParams that have values in the query

### DIFF
--- a/lib/queryUtil.js
+++ b/lib/queryUtil.js
@@ -28,15 +28,17 @@ module.exports = {
         });
     },
     buildAggregateQuery: function(year, keyParams, valueParams) {
+        var match = { activity_year: year };
         var group = { _id: {} };
         _.each(keyParams, function(param) {
+            match[param] = { $ne: '' };
             group._id[param] = '$' + param;
         });
         _.each(valueParams, function(param) {
             group._id[param] = '$' + param;
         });
         return [
-            { $match: { activity_year: year } },
+            { $match: match },
             { $group: group }
         ];
     }

--- a/test/lib/queryUtilSpec.js
+++ b/test/lib/queryUtilSpec.js
@@ -198,7 +198,8 @@ describe('queryUtil', function() {
             var expected = [
                 {
                     '$match': {
-                        'activity_year': '2013'
+                        'activity_year': '2013',
+                        'msa_code': { '$ne': '' }
                     }
                 },
                 {
@@ -221,7 +222,11 @@ describe('queryUtil', function() {
             var expected = [
                 {
                     '$match': {
-                        'activity_year': '2013'
+                        'activity_year': '2013',
+                        'state_code': { '$ne': '' },
+                        'county_code': { '$ne': '' },
+                        'tract': { '$ne': '' },
+                        'msa_code': { '$ne': '' }
                     }
                 },
                 {
@@ -247,7 +252,10 @@ describe('queryUtil', function() {
             var expected = [
                 {
                     '$match': {
-                        'activity_year': '2013'
+                        'activity_year': '2013',
+                        'state_code': { '$ne': '' },
+                        'county_code': { '$ne': '' },
+                        'tract': { '$ne': '' }
                     }
                 },
                 {
@@ -268,11 +276,15 @@ describe('queryUtil', function() {
             expect(_.isEqual(result, expected)).to.be(true);
             done();
         });
-        it('should build proper query for multiple keyParams and single valueParams, with overlapping key/value params', function(done) {
+        it('should build proper query for multiple keyParams and multiple valueParams, with overlapping key/value params', function(done) {
             var expected = [
                 {
                     '$match': {
-                        'activity_year': '2013'
+                        'activity_year': '2013',
+                        'state_code': { '$ne': '' },
+                        'county_code': { '$ne': '' },
+                        'tract': { '$ne': '' },
+                        'msa_code': { '$ne': '' }
                     }
                 },
                 {


### PR DESCRIPTION
Fixes an issue where we could have keys for local db generated without a proper RESTful URL type path.
e.g.  If `param2` has no value:
```json
{
   "key": "/param1/val1/param2//param3/val3"
}
```