### PR TITLE
Control how large the chunks are when sending localdb API data

### DIFF
--- a/controllers/localdb/census/index.js
+++ b/controllers/localdb/census/index.js
@@ -7,7 +7,16 @@ var sendResponse = function(req, res, keyParams, valueParams) {
         if (err) {
             res.status(500).json(err);
         } else {
-            res.json(result);
+            res.setHeader('Content-Type', 'application/json; charset=UTF-8');
+            res.setHeader('Transfer-Encoding', 'chunked');
+            res.write('[');
+            for (var i=0; i < result.length; i++) {
+                res.write(result[i].join(','));
+                if (i < result.length-1) {
+                    res.write(',');
+                }
+            }
+            res.end(']');
         }
     });
 };

--- a/lib/queryUtil.js
+++ b/lib/queryUtil.js
@@ -3,6 +3,23 @@
 var mongoose = require('mongoose'),
     _ = require('underscore');
 
+var _CHUNK_SIZE = 5000;
+
+var stringify = function(chunks) {
+    return _.map(chunks, function(bit) {
+        return JSON.stringify(bit);
+    });
+};
+
+var chunks = function(array, size) {
+  var results = [];
+  while (array.length) {
+    var chunk = stringify(array.splice(0, size));
+    results.push(chunk);
+  }
+  return results;
+};
+
 module.exports = {
     exists: function(domain, query, callback) {
         mongoose.model(domain).count(query, function(err, count) {
@@ -16,7 +33,7 @@ module.exports = {
         });
     },
     convertToKeyValue: function(keyPrefix, data, keyParams, valueParams) {
-        return _.map(data, function(row) {
+        return chunks(_.map(data, function(row) {
             var ob = { type: 'put', key: keyPrefix, value: {} };
             _.each(keyParams, function(param) {
                 ob.key += '/' + param + '/' + row._id[param];
@@ -25,7 +42,7 @@ module.exports = {
                 ob.value[param] = row._id[param];
             });
             return ob;
-        });
+        }), _CHUNK_SIZE);
     },
     buildAggregateQuery: function(year, keyParams, valueParams) {
         var match = { activity_year: year };

--- a/test/lib/queryUtilSpec.js
+++ b/test/lib/queryUtilSpec.js
@@ -38,22 +38,8 @@ describe('queryUtil', function() {
                     }
                 }
             ];
-            var expected = [
-                {
-                    type: 'put',
-                    key: 'census/msa_code/36060',
-                    value: {
-                        msa_name: 'Oak Hill, WV'
-                    }
-                },
-                {
-                    type: 'put',
-                    key: 'census/msa_code/43220',
-                    value: {
-                        msa_name: 'Shelton, WA'
-                    }
-                }
-            ];
+            var expected = [ [ '{"type":"put","key":"census/msa_code/36060","value":{"msa_name":"Oak Hill, WV"}}',
+    '{"type":"put","key":"census/msa_code/43220","value":{"msa_name":"Shelton, WA"}}' ] ];
             var keyParams = ['msa_code'];
             var valueParams = ['msa_name'];
             var result = queryUtil.convertToKeyValue('census', data, keyParams, valueParams);
@@ -77,24 +63,8 @@ describe('queryUtil', function() {
                     }
                 }
             ];
-            var expected = [
-                {
-                    type: 'put',
-                    key: 'census/msa_code/36060',
-                    value: {
-                        msa_name: 'Oak Hill, WV',
-                        small_county: '1'
-                    }
-                },
-                {
-                    type: 'put',
-                    key: 'census/msa_code/43220',
-                    value: {
-                        msa_name: 'Shelton, WA',
-                        small_county: '0'
-                    }
-                }
-            ];
+            var expected = [ [ '{"type":"put","key":"census/msa_code/36060","value":{"msa_name":"Oak Hill, WV","small_county":"1"}}',
+    '{"type":"put","key":"census/msa_code/43220","value":{"msa_name":"Shelton, WA","small_county":"0"}}' ] ];
             var keyParams = ['msa_code'];
             var valueParams = ['msa_name', 'small_county'];
             var result = queryUtil.convertToKeyValue('census', data, keyParams, valueParams);
@@ -122,22 +92,8 @@ describe('queryUtil', function() {
                     }
                 }
             ];
-            var expected = [
-                {
-                    type: 'put',
-                    key: 'census/state_code/01/county_code/02/tract/03/msa_code/36060',
-                    value:  {
-                        msa_name: 'Oak Hill, WV'
-                    }
-                },
-                {
-                    type: 'put',
-                    key: 'census/state_code/03/county_code/02/tract/01/msa_code/43220',
-                    value: {
-                        msa_name: 'Shelton, WA'
-                    }
-                }
-            ];
+            var expected = [ [ '{"type":"put","key":"census/state_code/01/county_code/02/tract/03/msa_code/36060","value":{"msa_name":"Oak Hill, WV"}}',
+    '{"type":"put","key":"census/state_code/03/county_code/02/tract/01/msa_code/43220","value":{"msa_name":"Shelton, WA"}}' ] ];
             var keyParams = ['state_code', 'county_code', 'tract', 'msa_code'];
             var valueParams = ['msa_name'];
             var result = queryUtil.convertToKeyValue('census', data, keyParams, valueParams);
@@ -167,24 +123,8 @@ describe('queryUtil', function() {
                     }
                 }
             ];
-            var expected = [
-                {
-                    type: 'put',
-                    key: 'census/state_code/01/county_code/02/tract/03/msa_code/36060',
-                    value:  {
-                        msa_name: 'Oak Hill, WV',
-                        small_county: '1'
-                    }
-                },
-                {
-                    type: 'put',
-                    key: 'census/state_code/03/county_code/02/tract/01/msa_code/43220',
-                    value: {
-                        msa_name: 'Shelton, WA',
-                        small_county: '0'
-                    }
-                }
-            ];
+            var expected = [ [ '{"type":"put","key":"census/state_code/01/county_code/02/tract/03/msa_code/36060","value":{"msa_name":"Oak Hill, WV","small_county":"1"}}',
+    '{"type":"put","key":"census/state_code/03/county_code/02/tract/01/msa_code/43220","value":{"msa_name":"Shelton, WA","small_county":"0"}}' ] ];
             var keyParams = ['state_code', 'county_code', 'tract', 'msa_code'];
             var valueParams = ['msa_name', 'small_county'];
             var result = queryUtil.convertToKeyValue('census', data, keyParams, valueParams);


### PR DESCRIPTION
By telling the browser that we are sending `chunked` data (via `Transfer-encoding` header), we can control the size of each `on('data')` chunk seen in the engine. This allows us to control how many times we have to call `on('data')`, which controls the size of the hidden classes generated by the body concatenation.