### PR TITLE
Solve issue of travis deploying twice in node version matrix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ deploy:
   upload-dir: develop
   on:
     all_branches: true
+    node: '0.10'
 - provider: codedeploy
   access_key_id: AKIAIMTOX4BXGVFOB56Q
   secret_access_key:
@@ -29,6 +30,7 @@ deploy:
   deployment_group: hmda-edit-check-api-dev
   on:
     all_branches: true
+    node: '0.10'
 - provider: s3
   access_key_id: AKIAIMTOX4BXGVFOB56Q
   secret_access_key:
@@ -39,6 +41,7 @@ deploy:
   upload-dir: master
   on:
     branch: master
+    node: '0.10'
 - provider: codedeploy
   access_key_id: AKIAIMTOX4BXGVFOB56Q
   secret_access_key:
@@ -49,6 +52,7 @@ deploy:
   deployment_group: hmda-edit-check-api-prod
   on:
     branch: master
+    node: '0.10'
 notifications:
   hipchat:
     rooms:


### PR DESCRIPTION
Have the deploy process check that we're on build for version 0.10 of node, since that's what is currently installed in AWS, so we only deploy once.