### PR TITLE
Bson/version bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "kraken-js": "^1.0.5",
     "localizr": "^1.0.5",
     "moment": "^2.10.2",
-    "mongoose": "4.0.2",
+    "mongoose": "^4.1.8",
     "lodash": "^3.7.0",
     "superagent": "^1.2.0",
     "bluebird": "^2.9.25"
@@ -51,7 +51,7 @@
     "istanbul": "^0.3.13",
     "jscs-stylish": "^0.3.1",
     "mocha": "^2.2.4",
-    "mockgoose": "~2.0.1",
+    "mockgoose": "^4.0.1",
     "must": "^0.12.0",
     "rewire": "^2.3.3",
     "spec-xunit-file": "0.0.1-3",
@@ -65,3 +65,4 @@
     "task": "grunt"
   }
 }
+

--- a/run-docker-containers.sh
+++ b/run-docker-containers.sh
@@ -8,6 +8,6 @@ docker run -d --name hmda-pilot-mongodb hmda-pilot-mongodb
 # Remove any current container for the api
 docker rm -f hmda-pilot-api
 # Run the api container, linking in the mongodb container
-docker run -d --link hmda-pilot-mongodb --name hmda-pilot-api -p 8000:8000 hmda-pilot-api
+docker run -d --link hmda-pilot-mongodb:hmda-pilot-mongodb --name hmda-pilot-api -p 8000:8000 hmda-pilot-api
 # exec a nodejs script in the api container to reload the database
 docker exec -it hmda-pilot-api gosu nodejs node /usr/local/node/hmda-edit-check-api/data/reload_mongo.js


### PR DESCRIPTION
Updated mongoose/mockgoose versions, which causes the bson bug to go away on install, but grunt test still passes.

Also fixed a linked bug in the run-docker-containers.sh script