### PR TITLE
Streamline dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,8 +34,6 @@ node_modules
 
 docs
 
-# ingore mongo-docker
-mongo-docker
 
 build-docker-containers.sh
 run-docker-containers.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/local/node/hmda-edit-check-api
 # Set the environment
 ENV NODE_ENV=production PORT=8000 NODE_TLS_REJECT_UNAUTHORIZED=0
 
-#
+# Install deps and app files
 RUN ./docker-scripts/run.sh
 
 # Ensure proper build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM alpine:3.2
+FROM mhart/alpine-node:0.10
 
 # Add source and make sure we're working in that dir
 ADD . /usr/local/node/hmda-edit-check-api
 WORKDIR /usr/local/node/hmda-edit-check-api
 
 # Set the environment
-ENV NODE_VERSION=v0.12.5 NODE_ENV=production PORT=8000 NODE_TLS_REJECT_UNAUTHORIZED=0
+ENV NODE_ENV=production PORT=8000 NODE_TLS_REJECT_UNAUTHORIZED=0
 
-# Use a custom build script instead of messy chained together RUN
-# or multiple RUN statements that add bloat to the image
+#
 RUN ./docker-scripts/run.sh
 
-# Tests. Yes, Virginia, you can test Docker builds
+# Ensure proper build
 RUN ./docker-scripts/tests.sh
 
 EXPOSE ${PORT}
-COPY ./docker-scripts/entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+
+USER notroot
+
 CMD ["node", "server.js"]

--- a/docker-scripts/run.sh
+++ b/docker-scripts/run.sh
@@ -1,46 +1,19 @@
 #!/bin/sh
 
 ##### add dependencies
-apk --update add bash git curl make gcc g++ python linux-headers paxctl libgcc libstdc++
-# We need shadow to create user/group for node, requires testing repo at this time
-apk add shadow --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/
-
-
-##### add our nodejs user and group first to make sure their IDs get assigned consistently
-groupadd -r nodejs -g 1000
-useradd -u 1000 -r -g 1000 -d /usr/local/node nodejs
-chown -R nodejs:nodejs /usr/local/node
-
-##### install gosu for easy step-down from root
-echo -n "--- installing gosu... "
-curl -o /usr/local/bin/gosu -sSL https://github.com/tianon/gosu/releases/download/1.4/gosu-amd64
-chmod +x /usr/local/bin/gosu
-echo "done"
-
-##### Compile and install nodejs
-CONFIG_FLAGS="--prefix=/usr"
-CMD=node
-DOMAIN=nodejs.org
-
-cd /tmp
-curl -sSL https://${DOMAIN}/dist/${NODE_VERSION}/${CMD}-${NODE_VERSION}.tar.gz | tar -xz && \
-  cd /tmp/${CMD}-${NODE_VERSION} && \
-  ./configure ${CONFIG_FLAGS} && \
-  make -j$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) && \
-  make install && \
-  paxctl -cm /usr/bin/${CMD} && \
-  cd / && \
-  if [ -x /usr/bin/npm ]; then \
-    npm install -g npm && \
-    find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf; \
-  fi && \
+apk --update add git make g++ python
 
 ##### do npm install on the app so it has all the proper modules
 cd /usr/local/node/hmda-edit-check-api
-gosu nodejs npm cache clean && npm install
+npm cache clean && npm install
+
+##### add a non-root user
+adduser -S notroot
+chown -R notroot .
+
 
 ##### clean up
-apk del git curl make gcc g++ python linux-headers paxctl
+apk del git make gcc g++ python 
 rm -rf /etc/ssl /usr/include /usr/share/man /tmp/* \
     /usr/include /root/.npm /root/.node-gyp \
     /usr/local/node/.npm /usr/local/node/.node-gyp \

--- a/docker-scripts/tests.sh
+++ b/docker-scripts/tests.sh
@@ -2,12 +2,7 @@
 
 echo --- TESTS ---
 
-echo -n "it should install gosu 1.4... "
-gosu 2>&1 | grep "version: 1.4" > /dev/null
-[ "$?" -ne 0 ] && echo fail && exit 1
-echo pass
-
-echo -n "it should install nodejs 0.12.5... "
-node --version 2>&1 | grep "0.12.5" > /dev/null
+echo -n "it should install nodejs 0.10.x"
+node --version 2>&1 | grep "0.10" > /dev/null
 [ "$?" -ne 0 ] && echo fail && exit 1
 echo pass

--- a/mongo-docker/Dockerfile
+++ b/mongo-docker/Dockerfile
@@ -14,5 +14,7 @@ RUN /tmp/tests.sh && rm /tmp/tests.sh
 COPY . /usr/local/app
 RUN /tmp/install-app.sh && rm /tmp/install-app.sh
 
+ENTRYPOINT ["/tmp/entrypoint.sh"]
+
 EXPOSE 27017
-CMD ["/tmp/start.sh"]
+CMD ["mongod"]

--- a/mongo-docker/Dockerfile
+++ b/mongo-docker/Dockerfile
@@ -1,18 +1,18 @@
-# Based roughly around official MongoDB docker image
-# https://github.com/docker-library/mongo/blob/master/2.6/Dockerfile
-FROM alpine:3.2
+FROM mhart/alpine-node:0.10
 
-# Use a custom build script instead of messy chained together RUN
-# or multiple RUN statements that add bloat to the image
-ADD run.sh /tmp/run.sh
+ENV NODE_ENV=production
+
+COPY mongo-docker /tmp
+
+# Build
 RUN /tmp/run.sh && rm /tmp/run.sh
 
-# Tests. Yes, Virginia, you can test Docker builds
-ADD tests.sh /tmp/tests.sh
+# Tests
 RUN /tmp/tests.sh && rm /tmp/tests.sh
 
-VOLUME /data/db
-COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# Install app
+COPY . /usr/local/app
+RUN /tmp/install-app.sh && rm /tmp/install-app.sh
+
 EXPOSE 27017
-CMD ["mongod"]
+CMD ["/tmp/start.sh"]

--- a/mongo-docker/entrypoint.sh
+++ b/mongo-docker/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+/tmp/reload.sh&
+
 set -e
 
 if [ "${1:0:1}" = '-' ]; then

--- a/mongo-docker/install-app.sh
+++ b/mongo-docker/install-app.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+apk --update add make g++ python git
+
+# Install app deps
+cd /usr/local/app
+npm install
+
+# Clean
+apk del make g++ git python
+rm -rf /var/cache/apk/*

--- a/mongo-docker/reload.sh
+++ b/mongo-docker/reload.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Wait for mongod to start
+sleep 10
+
+node /usr/local/app/data/reload_mongo.js

--- a/mongo-docker/run.sh
+++ b/mongo-docker/run.sh
@@ -37,6 +37,9 @@ chown -R root:root /tmp/mongodb-linux-x86_64-$MONGO_VERSION
 mv /tmp/mongodb-linux-x86_64-$MONGO_VERSION/bin/* /usr/local/bin
 echo "done"
 
+##### create app area for data loading
+mkdir -p /usr/local/app
+
 ##### Clean up after ourselves
 # We don't need wget any longer
 apk del wget

--- a/mongo-docker/start.sh
+++ b/mongo-docker/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Start mongo
+/tmp/entrypoint.sh mongod&
+
+sleep 5
+
+# Load data
+node /usr/local/app/data/reload_mongo.js

--- a/mongo-docker/start.sh
+++ b/mongo-docker/start.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Start mongo
-/tmp/entrypoint.sh mongod&
-
-sleep 5
-
-# Load data
-node /usr/local/app/data/reload_mongo.js


### PR DESCRIPTION
Changes to both dockerfiles herein. Main changes:

* api container no longer builds node from source
* mongo container loads data on startup (though the context needed to be expanded to allow run the reloading script
